### PR TITLE
Add Picker API.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.10.4
+erlang 23.0.1
+nodejs 14.9.0

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -1,0 +1,26 @@
+defmodule Memo.Temporary.Library.Picker do
+  @moduledoc """
+  Picker API. Provides 4 functions:
+
+  * List passages
+  * Fetch a passage
+  * Get next passage
+  * Get prev passage
+  """
+
+  def list() do
+    []
+  end
+
+  def fetch(id) do
+    nil
+  end
+
+  def next(id) do
+    nil
+  end
+
+  def prev(id) do
+    nil
+  end
+end

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -41,6 +41,7 @@ defmodule Memo.Temporary.Library.Picker do
   @spec list() :: [passage()]
   def list() do
     @passages
+    |> Enum.sort_by(fn %{inserted_at: ia} -> ia end)
   end
 
   @doc """
@@ -51,11 +52,35 @@ defmodule Memo.Temporary.Library.Picker do
     @passages |> Enum.find(fn %{id: cid} -> cid == id end)
   end
 
-  def next(id) do
-    nil
+  @doc """
+  Fetches the next passage given an id.
+  """
+  @spec next(passage) :: passage()
+  def next(%{inserted_at: ia} = _current_passage) do
+    passages = list()
+
+    Enum.find(
+      passages,
+      hd(passages),
+      fn %{inserted_at: cia} = _cpassage ->
+        cia > ia
+      end
+    )
   end
 
-  def prev(id) do
-    nil
+  @doc """
+  Fetches the prev passage given an id.
+  """
+  @spec prev(passage) :: passage()
+  def prev(%{inserted_at: ia} = _current_passage) do
+    passages = list()
+
+    Enum.find(
+      passages,
+      tl(passages),
+      fn %{inserted_at: cia} = _cpassage ->
+        cia < ia
+      end
+    )
   end
 end

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -15,10 +15,28 @@ defmodule Memo.Temporary.Library.Picker do
     %{id: :macbeth, name: "Macbeth", body: "Out damn spot, out!"}
   ]
 
+  @typedoc """
+  Id for a passage.
+  """
+  @type passage_id :: atom
+
+  @typedoc """
+  The type of a passage, currently a map.
+  """
+  @type passage :: map()
+
+  @doc """
+  Lists the available passages.
+  """
+  @spec list() :: [passage()]
   def list() do
     @passages
   end
 
+  @doc """
+  Fetches a passage given its id.
+  """
+  @spec fetch(passage_id) :: passage()
   def fetch(id) do
     @passages |> Enum.find(fn %{id: cid} -> cid == id end)
   end

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -8,8 +8,15 @@ defmodule Memo.Temporary.Library.Picker do
   * Get prev passage
   """
 
+  @passages [
+    %{id: :futurama, name: "Futurama", body: "Good news everyone!"},
+    %{id: :it_crowd, name: "IT Crowd", body: "Have you tried turning it on and off again?"},
+    %{id: :hamlet, name: "Hamlet", body: "To be or not to be, that is the question."},
+    %{id: :macbeth, name: "Macbeth", body: "Out damn spot, out!"}
+  ]
+
   def list() do
-    []
+    @passages
   end
 
   def fetch(id) do

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -9,10 +9,20 @@ defmodule Memo.Temporary.Library.Picker do
   """
 
   @passages [
-    %{id: :futurama, name: "Futurama", body: "Good news everyone!"},
-    %{id: :it_crowd, name: "IT Crowd", body: "Have you tried turning it on and off again?"},
-    %{id: :hamlet, name: "Hamlet", body: "To be or not to be, that is the question."},
-    %{id: :macbeth, name: "Macbeth", body: "Out damn spot, out!"}
+    %{id: :futurama, name: "Futurama", body: "Good news everyone!", inserted_at: 0},
+    %{
+      id: :it_crowd,
+      name: "IT Crowd",
+      body: "Have you tried turning it on and off again?",
+      inserted_at: 1
+    },
+    %{
+      id: :hamlet,
+      name: "Hamlet",
+      body: "To be or not to be, that is the question.",
+      inserted_at: 2
+    },
+    %{id: :macbeth, name: "Macbeth", body: "Out damn spot, out!", inserted_at: 3}
   ]
 
   @typedoc """

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -20,7 +20,7 @@ defmodule Memo.Temporary.Library.Picker do
   end
 
   def fetch(id) do
-    nil
+    @passages |> Enum.find(fn %{id: cid} -> cid == id end)
   end
 
   def next(id) do

--- a/memo/lib/memo/temporary/library/picker.ex
+++ b/memo/lib/memo/temporary/library/picker.ex
@@ -73,11 +73,11 @@ defmodule Memo.Temporary.Library.Picker do
   """
   @spec prev(passage) :: passage()
   def prev(%{inserted_at: ia} = _current_passage) do
-    passages = list()
+    passages = list() |> Enum.reverse()
 
     Enum.find(
       passages,
-      tl(passages),
+      List.first(passages),
       fn %{inserted_at: cia} = _cpassage ->
         cia < ia
       end

--- a/memo/test/memo/picker_test.exs
+++ b/memo/test/memo/picker_test.exs
@@ -23,13 +23,31 @@ defmodule Memo.PickerTest do
     end
   end
 
-  describe "linking api" do
-    test "next should return the next passage" do
-      assert Picker.next(:macbeth)
+  describe "next api" do
+    test "on first element should return second" do
+      futurama = Picker.fetch(:futurama)
+      it_crowd = Picker.fetch(:it_crowd)
+      assert Picker.next(futurama) == it_crowd
     end
 
-    test "prev should return the previous passage" do
-      assert false
+    test "on final element should return first" do
+      macbeth = Picker.fetch(:macbeth)
+      futurama = Picker.fetch(:futurama)
+      assert Picker.next(macbeth) == futurama
+    end
+  end
+
+  describe "prev api" do
+    test "on last element should return previous" do
+      macbeth = Picker.fetch(:macbeth)
+      hamlet = Picker.fetch(:hamlet)
+      assert Picker.prev(macbeth) == hamlet
+    end
+
+    test "on first element should return final" do
+      macbeth = Picker.fetch(:macbeth)
+      futurama = Picker.fetch(:futurama)
+      assert Picker.prev(futurama) == macbeth
     end
   end
 end

--- a/memo/test/memo/picker_test.exs
+++ b/memo/test/memo/picker_test.exs
@@ -17,8 +17,19 @@ defmodule Memo.PickerTest do
       assert Picker.fetch(@valid_id) == %{
                id: :macbeth,
                name: "Macbeth",
-               body: "Out damn spot, out!"
+               body: "Out damn spot, out!",
+               inserted_at: 3
              }
+    end
+  end
+
+  describe "linking api" do
+    test "next should return the next passage" do
+      assert Picker.next(:macbeth)
+    end
+
+    test "prev should return the previous passage" do
+      assert false
     end
   end
 end

--- a/memo/test/memo/picker_test.exs
+++ b/memo/test/memo/picker_test.exs
@@ -1,0 +1,11 @@
+defmodule Memo.PickerTest do
+  alias Memo.Temporary.Library.Picker
+  use ExUnit.Case
+
+  @tag :picker
+  describe "list api" do
+    test "should be non-empty" do
+      assert length(Picker.list()) > 0
+    end
+  end
+end

--- a/memo/test/memo/picker_test.exs
+++ b/memo/test/memo/picker_test.exs
@@ -2,7 +2,8 @@ defmodule Memo.PickerTest do
   alias Memo.Temporary.Library.Picker
   use ExUnit.Case
 
-  @tag :picker
+  @moduletag :picker
+
   describe "list api" do
     test "should be non-empty" do
       assert length(Picker.list()) > 0
@@ -11,7 +12,6 @@ defmodule Memo.PickerTest do
 
   @valid_id :macbeth
 
-  @tag :picker
   describe "fetch api" do
     test "should return a passage given valid id" do
       assert Picker.fetch(@valid_id) == %{
@@ -23,30 +23,39 @@ defmodule Memo.PickerTest do
     end
   end
 
+  def get_passages() do
+    %{
+      futurama: Picker.fetch(:futurama),
+      it_crowd: Picker.fetch(:it_crowd),
+      macbeth: Picker.fetch(:macbeth),
+      hamlet: Picker.fetch(:hamlet)
+    }
+  end
+
   describe "next api" do
-    test "on first element should return second" do
-      futurama = Picker.fetch(:futurama)
-      it_crowd = Picker.fetch(:it_crowd)
+    setup do
+      get_passages()
+    end
+
+    test "on first element should return second", %{futurama: futurama, it_crowd: it_crowd} do
       assert Picker.next(futurama) == it_crowd
     end
 
-    test "on final element should return first" do
-      macbeth = Picker.fetch(:macbeth)
-      futurama = Picker.fetch(:futurama)
+    test "on final element should return first", %{futurama: futurama, macbeth: macbeth} do
       assert Picker.next(macbeth) == futurama
     end
   end
 
   describe "prev api" do
-    test "on last element should return previous" do
-      macbeth = Picker.fetch(:macbeth)
-      hamlet = Picker.fetch(:hamlet)
+    setup do
+      get_passages()
+    end
+
+    test "on last element should return previous", %{macbeth: macbeth, hamlet: hamlet} do
       assert Picker.prev(macbeth) == hamlet
     end
 
-    test "on first element should return final" do
-      macbeth = Picker.fetch(:macbeth)
-      futurama = Picker.fetch(:futurama)
+    test "on first element should return final", %{macbeth: macbeth, futurama: futurama} do
       assert Picker.prev(futurama) == macbeth
     end
   end

--- a/memo/test/memo/picker_test.exs
+++ b/memo/test/memo/picker_test.exs
@@ -8,4 +8,17 @@ defmodule Memo.PickerTest do
       assert length(Picker.list()) > 0
     end
   end
+
+  @valid_id :macbeth
+
+  @tag :picker
+  describe "fetch api" do
+    test "should return a passage given valid id" do
+      assert Picker.fetch(@valid_id) == %{
+               id: :macbeth,
+               name: "Macbeth",
+               body: "Out damn spot, out!"
+             }
+    end
+  end
 end


### PR DESCRIPTION
This adds the first version of the picker API, and also tests. Note that this uses a little bit of a janky assumption for how passages are stored--Ecto will change things significantly.
